### PR TITLE
Add delay to allow for audio load in test

### DIFF
--- a/test/record.creation.spec.ts
+++ b/test/record.creation.spec.ts
@@ -128,6 +128,8 @@ test('Can create/edit a manual record', async () => {
   await page.locator('#call-count').fill('3');
   await page.locator('#record-comment').fill('a test comment');
   await page.locator('#record-add').click();
+  // wait for audio to load
+  await page.waitForTimeout(300);
   const confidence = await page.locator('#result1 td.cname');
 
   // Confidence has been changed to Person_add icon


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added a short wait after clicking the record-add button in the manual record creation test to improve test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->