### PR TITLE
Fixes for issues noted in #306

### DIFF
--- a/js/worker.js
+++ b/js/worker.js
@@ -1417,6 +1417,8 @@ async function onAnalyse({
     if (!STATE.detect.combine){
       await memoryDB.runAsync("DELETE FROM records; VACUUM");
     }
+    // Clear any location filters set in explore/charts
+    STATE.locationID = undefined,  
     //create a copy of files in scope for state, as filesInScope is spliced
     STATE.setFiles([...filesInScope]);
   }

--- a/js/worker.js
+++ b/js/worker.js
@@ -1418,7 +1418,7 @@ async function onAnalyse({
       await memoryDB.runAsync("DELETE FROM records; VACUUM");
     }
     // Clear any location filters set in explore/charts
-    STATE.locationID = undefined,  
+    STATE.locationID = undefined;
     //create a copy of files in scope for state, as filesInScope is spliced
     STATE.setFiles([...filesInScope]);
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Chirpity",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "Chirpity Nocmig",
   "main": "main.js",
   "scripts": {
@@ -213,7 +213,7 @@
     "suncalc": "^1.9.0",
     "utimes": "^5.2.1",
     "uuid": "^8.3.2",
-    "wavesurfer.js": "^7.9.4"
+    "wavesurfer.js": "^7.9.5"
   },
   "optionalDependencies": {
     "ntsuspend": "^1.0.2"


### PR DESCRIPTION
* Location filter set in explore would be applied in new files' analysis
* reInitSpec on open files, so if it had been destroyed after visiting charts, it will load files again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of location filters to ensure they are properly cleared when switching between analysis, charts, and explore modes.
  - Enhanced species filtering logic to allow explicit override of default filters.

- **Chores**
  - Updated the app version to 4.0.4.
  - Upgraded the "wavesurfer.js" dependency to version 7.9.5.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->