### PR TITLE
change node version in runners

### DIFF
--- a/.github/workflows/Build-for-Intel-Mac.yml
+++ b/.github/workflows/Build-for-Intel-Mac.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-            node-version: 20.0.x
+            node-version: 22.16.0
       - run: echo "🍏 Node setup status is ${{ job.status }}."
       
       # Step to set up Python 3.11

--- a/.github/workflows/check-installation.yml
+++ b/.github/workflows/check-installation.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-            node-version: 20.0.x
+            node-version: 22.16.0
       - run: echo "🍏 Node setup status is ${{ job.status }}."
       
       # Step to set up Python 3.11


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Node.js version used in GitHub Actions workflows to 22.16.0 for improved consistency and reliability in build and installation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->