### PR TITLE
Derive multi-match token from customLabels in Model.setList; v5.1.2

### DIFF
--- a/js/models/listWorker.js
+++ b/js/models/listWorker.js
@@ -336,12 +336,12 @@ class Model {
             let selectedIndexes = [];
             if (indexes.length > 1) { // Multiple matches
               const labelOverride = this.customLabels[i].endsWith("-");
-              // Extract word in brackets from current index of this.labels
+              // Extract word in brackets from current index of this.customLabels
               const match = this.customLabels[i].match(/\((.*?)\)/);
               const callType = match ? match[0] : labelOverride ? '-' : null;
               for (let idx of indexes) {
                 if (callType) {
-                  // Check if the word in brackets exists in the custom list at the same index position
+                  // Check if the word in brackets exists in this label
                   if (this.labels[idx].endsWith(callType)) {
                     selectedIndexes.push(idx + 1);
                   }

--- a/js/models/listWorker.js
+++ b/js/models/listWorker.js
@@ -334,16 +334,15 @@ class Model {
           const indexes = findAllIndexes(labelsScientificNames, sname);
           if (indexes.length) {
             let selectedIndexes = [];
-            if (indexes.length > 1) {
-              // Multiple matches
+            if (indexes.length > 1) { // Multiple matches
               const labelOverride = this.customLabels[i].endsWith("-");
+              // Extract word in brackets from current index of this.labels
+              const match = this.customLabels[i].match(/\((.*?)\)/);
+              const callType = match ? match[0] : labelOverride ? '-' : null;
               for (let idx of indexes) {
-                // Extract word in brackets from current index of this.labels
-                const match = this.labels[idx].match(/\((.*?)\)/);
-                const qualifier = match ? match[0] : labelOverride ? '-' : null;
-                if (qualifier) {
+                if (callType) {
                   // Check if the word in brackets exists in the custom list at the same index position
-                  if (this.labels[idx].endsWith(qualifier)) {
+                  if (this.labels[idx].endsWith(callType)) {
                     selectedIndexes.push(idx + 1);
                   }
                 } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Chirpity",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "description": "Chirpity Nocmig",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multi-match behavior for custom labels so results are filtered more predictably when multiple matches exist; single-match behavior unchanged.
  * Better handling of label-derived qualifiers to reduce incorrect filtering and inconsistent match results.

* **Chores**
  * Bumped application version to 5.1.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->