### PR TITLE
move ffmpeg.setffmpegpath

### DIFF
--- a/js/worker.js
+++ b/js/worker.js
@@ -8,7 +8,12 @@ const fs = require("node:fs");
 const p = require("node:path");
 const SunCalc = require("suncalc");
 const ffmpeg = require("fluent-ffmpeg");
-
+const ffmpegPath = require("@ffmpeg-installer/ffmpeg").path.replace(
+  "app.asar",
+  "app.asar.unpacked"
+);
+console.log("cwd", __dirname)
+ffmpeg.setFfmpegPath(ffmpegPath);
 const merge = require("lodash.merge");
 import { WorkerState as State } from "./utils/state.js";
 import {
@@ -158,11 +163,7 @@ Date.prototype.getWeekNumber = function () {
   return Math.ceil((((d - yearStart) / 86400000 + 1) / 7) * (48 / 52));
 };
 
-const ffmpegPath = require("@ffmpeg-installer/ffmpeg").path.replace(
-  "app.asar",
-  "app.asar.unpacked"
-);
-ffmpeg.setFfmpegPath(ffmpegPath);
+
 let predictionsRequested = {},
   predictionsReceived = {},
   filesBeingProcessed = [];

--- a/main.js
+++ b/main.js
@@ -35,7 +35,7 @@ async function getInstallInfo(date) {
         // This is an ISO date string
         return parsed.installedAt;
       }
-      console.warn("getInstallInfo: keychain entry missing valid installedAt, recreating.");
+      console.warn("getInstallInfo: keychain entry missing valid installedAt, recreating with", date);
     }
   } catch (error) {
     console.warn("getInstallInfo: keychain read/parse failed, recreating:", error.message);


### PR DESCRIPTION
log date when keychain recreated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed FFmpeg path initialization to occur at the correct startup stage, ensuring proper availability when needed by the application.
  
* **Improvements**
  * Enhanced warning messages to include relevant date information for better debugging and user context.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->