### PR TITLE
universal mac not working, back to separate builds

### DIFF
--- a/.github/workflows/Build-for-Intel-Mac.yml
+++ b/.github/workflows/Build-for-Intel-Mac.yml
@@ -114,11 +114,6 @@ jobs:
         run: |
           npm install
           echo "Install's status is ${{ job.status }}."
-
-      # - name: Audit fix
-      #   run: |
-      #     npm audit fix
-      #     echo "Audit fix applied, status is ${{ job.status }}."
           
       - name: Set platform-specific ffmpeg path
         shell: bash

--- a/.github/workflows/check-installation.yml
+++ b/.github/workflows/check-installation.yml
@@ -215,7 +215,7 @@ jobs:
           if [[ "$RUNNER_OS" == "Windows" ]]; then
             FILENAME="Chirpity Setup $VERSION.exe"
           elif [[ "$RUNNER_OS" == "macOS" ]]; then
-            FILENAME="Chirpity.dmg"
+            FILENAME="Chirpity-${arch}.dmg"
           else
             FILENAME="Chirpity-x64.AppImage"
           fi
@@ -232,6 +232,7 @@ jobs:
       # Download Perch
 
       - name: Cache Perch model archive
+        if: runner.os != 'Linux'
         id: cache-perch
         uses: actions/cache@v4
         with:
@@ -239,13 +240,14 @@ jobs:
           key: perch-model-v2-7z
 
       - name: Download Perch Sound Model
-        if: steps.cache-perch.outputs.cache-hit != 'true'
+        if: runner.os != 'Linux' && steps.cache-perch.outputs.cache-hit != 'true'
         run: |
           curl -L -o Perch.v2.7z \
             https://github.com/Mattk70/Chirpity-Website/releases/download/v3.0.0/Perch.v2.7z
         shell: bash
 
       - name: Extract Perch Model
+        if: runner.os != 'Linux'
         shell: bash
         run: |
           echo "Extracting Perch model on $RUNNER_OS"
@@ -264,6 +266,7 @@ jobs:
 
 
       - name: Make model available to Playwright
+        if: runner.os != 'Linux'
         shell: bash
         run: |
           # Cross-platform: use GITHUB_WORKSPACE for Windows paths
@@ -277,12 +280,4 @@ jobs:
       - name: Test packaged application
         if: runner.os != 'Linux'
         run: npm test
-
-      # - name: Set locale to de_DE.UTF-8 for Mac, before testing application
-      #   if: runner.os == 'macOS'
-      #   run: |
-      #       export LC_ALL=de_DE.UTF-8
-      #       export LANG=de_DE.UTF-8
-      #       python -c "import locale; locale.setlocale(locale.LC_ALL, locale.getlocale()[0]); print(locale.localeconv())"
-      #       LANG=de_DE.UTF-8 LC_ALL=de_DE.UTF-8 npm test
 

--- a/package.json
+++ b/package.json
@@ -121,10 +121,9 @@
     "mac": {
       "target": {
         "target": "dmg",
-        "arch": ["universal"]
+        "arch": ["arm64"]
       },
-      "singleArchFiles": "*",
-      "artifactName": "${productName}.${ext}",
+      "artifactName": "${productName}-${arch.${ext}",
       "type": "distribution",
       "hardenedRuntime": true,
       "entitlements": "build/entitlements.mac.plist",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS build configuration to target ARM64 architecture exclusively
  * Enhanced CI/CD workflows for improved cross-platform compatibility and model handling
  * Refined macOS installer naming convention to reflect build architecture

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->