### PR TITLE
autoInstallOnAppQuit for macs

### DIFF
--- a/main.js
+++ b/main.js
@@ -239,6 +239,7 @@ autoUpdater.on("download-progress", function (progressObj) {
 });
 
 autoUpdater.on("update-downloaded", async function (info) {
+  if (isMac) {autoUpdater.autoInstallOnAppQuit();return}
   // Fetch release notes from GitHub API
   const releaseNotes = await fetchReleaseNotes(info.version);
   log.info(JSON.stringify(info));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * **macOS Update Handler**: Updated the auto-update behavior for macOS. When an update is downloaded and the application exits, the update will now automatically install without prompting the user with a dialog or showing release notes. This change simplifies the update process and ensures updates are installed promptly without requiring user interaction.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->