### PR TITLE
enable updatecheck for intel mac and run test for linux

### DIFF
--- a/.github/workflows/check-installation.yml
+++ b/.github/workflows/check-installation.yml
@@ -147,8 +147,6 @@ jobs:
       - name: Start Xvfb
         if: runner.os == 'Linux'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y xvfb
           Xvfb :99 -screen 0 1280x1024x24 &
           # Set DISPLAY environment variable
           echo "DISPLAY=:99" >> $GITHUB_ENV
@@ -282,6 +280,6 @@ jobs:
 
 
       - name: Test packaged application
-        if: runner.os != 'Linux'
+        # if: runner.os != 'Linux'
         run: npm test
 

--- a/js/ui.js
+++ b/js/ui.js
@@ -2120,7 +2120,7 @@ window.onload = async () => {
     trackVisit(config);
 
     // check for new version on Intel mac platform. dmg auto-update not yet working
-    window.electron.isIntelMac() && !isTestEnv && checkForIntelMacUpdates();
+    // window.electron.isIntelMac() && !isTestEnv && checkForIntelMacUpdates();
 
   });
 };

--- a/main.js
+++ b/main.js
@@ -623,7 +623,7 @@ app.whenReady().then(async () => {
         })
     });
     //Update handling
-    if (process.env.CI || isIntelMac) {
+    if (process.env.CI) {
         console.log("Auto-updater disabled in CI environment. And doesn't work for Intel mac");
     } else {
         autoUpdater.autoDownload = false;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Chirpity",
-  "version": "5.6.0",
+  "version": "5.7.0",
   "description": "Chirpity is a bioacoustics platform for the analysis of bird song and other wildlife sounds. It uses machine learning models to identify bird species from audio recordings.",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled auto-updates for Intel Mac users. Previously disabled, auto-updates are now available on Intel Mac systems.
  * Removed Intel Mac-specific update check from UI initialization.

* **Chores**
  * Version bump to 5.7.0.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->