### PR TITLE
don't check for intel macs the old way

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -2120,7 +2120,7 @@ window.onload = async () => {
     trackVisit(config);
 
     // check for new version on Intel mac platform. dmg auto-update not yet working
-    window.electron.isIntelMac() && !isTestEnv && checkForIntelMacUpdates();
+    // window.electron.isIntelMac() && !isTestEnv && checkForIntelMacUpdates();
 
   });
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Chirpity",
-  "version": "5.6.0",
+  "version": "5.6.1",
   "description": "Chirpity is a bioacoustics platform for the analysis of bird song and other wildlife sounds. It uses machine learning models to identify bird species from audio recordings.",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
bump version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Intel Mac update check no longer executes at startup.

* **Chores**
  * Version bumped to 5.6.1.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->