### PR TITLE
Change species export format from text to CSV

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -4425,7 +4425,7 @@ const populateSpeciesModal = async ({included, excluded, place}) => {
 };
 
 /**
- * Save the current included species list as a plain-text CSV file and start a download named "species_list.txt".
+ * Save the current included species list as a plain-text CSV file and start a download named "species_list.csv".
  *
  * Each line contains the species scientific name and common name separated by a comma.
  */


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Species list export now downloads as a CSV file (correct .csv filename and CSV MIME type) instead of plain text. Download behavior and exported content remain the same; only file format and filename changed. This improves compatibility with spreadsheet applications and makes exported files easier to open.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
