### PR TITLE
Skip keychain access during CI and update dependencies

### DIFF
--- a/main.js
+++ b/main.js
@@ -92,6 +92,7 @@ let DEBUG = false;
  */
 
 async function getInstallInfo(date) {
+  if (!!process.env.CI) return { appId: 0, installedAt: Date.now() }; // Don't use keychain in CI, just return dummy data
   // First, try the current key (ACCOUNT = 'uuid')
   try {
     const raw = await keytar.getPassword(SERVICE, ACCOUNT);

--- a/main.js
+++ b/main.js
@@ -92,7 +92,7 @@ let DEBUG = false;
  */
 
 async function getInstallInfo(date) {
-  if (!!process.env.CI) return { appId: 0, installedAt: Date.now() }; // Don't use keychain in CI, just return dummy data
+  if (!!process.env.CI) return { appId: crypto.randomUUID(), installedAt: Date.now() }; // Don't use keychain in CI, just return dummy data
   // First, try the current key (ACCOUNT = 'uuid')
   try {
     const raw = await keytar.getPassword(SERVICE, ACCOUNT);

--- a/package.json
+++ b/package.json
@@ -217,7 +217,7 @@
     "@types/node": "^22.9.0",
     "assemblyscript": "^0.28.9",
     "docdash": "^2.0.2",
-    "electron": "^39.2.4",
+    "electron": "^39.8.10",
     "electron-builder": "26.0.12",
     "electron-builder-squirrel-windows": "26.0.12",
     "electron-playwright-helpers": "^1.7.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
         "path": "/Applications"
       }
     ],
-    "format": "ULFO",
+    "format": "ULMO",
     "internetEnabled": true
   },
   "build": {


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved keychain access issues during CI builds to prevent installation metadata retrieval failures.

* **Dependency Updates**
  * Updated Electron dependency to version 39.8.10.

* **Chores**
  * Updated macOS DMG layout configuration format.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mattk70/Chirpity-Electron/pull/604?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->