### PR TITLE
try skip install-scripts

### DIFF
--- a/.github/workflows/check-installation.yml
+++ b/.github/workflows/check-installation.yml
@@ -130,14 +130,9 @@ jobs:
         # npm audit fix is intentionally omitted: it mutates package-lock.json at
         # runtime, making builds non-reproducible. Fix vulnerabilities locally and
         # commit the updated lock file instead.
-        run: npm install
+        run: npm install  --ignore-scripts
 
 
-      - name: Inspect tfjs-node after failure
-        if: failure()
-        shell: pwsh
-        run: |
-          Get-ChildItem node_modules/@tensorflow/tfjs-node -Recurse | Select-Object FullName
           
       - name: Copy tensorflow.dll to napi-v8 folder
         if: runner.os == 'Windows'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the installation process in the build workflow to skip package lifecycle scripts during dependency install.
  * This helps make automated installs more predictable and reduces the risk of unexpected script execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->