### PR TITLE
Add Full File Paths to Tooltips and Style Comparison Timelines

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -836,37 +836,68 @@ function renderFilenamePanel() {
   const { parentFolder, fileName } = utils.extractFileNameAndFolder(openFile);
   const label = `${parentFolder}/${fileName}`;
   let appendStr;
-  const title = ` title="${openFile}\n---\n${i18.filename}" `;
+  const titleText = `${openFile}\n---\n${i18.filename}`;
   const isSaved = ["archive", "explore"].includes(STATE.mode)
     ? "text-info"
     : "text-warning";
+  // Build DOM elements to avoid injecting unescaped HTML into attributes
+  const container = document.createElement("div");
+  container.id = "fileContainer";
   if (files.length > 1) {
-    appendStr = `<div id="fileContainer" class="btn-group dropup pointer">
-        <span ${title} class="filename ${isSaved}">${label}</span>
-        </button>
-        <button id="filecount" class="btn btn-dark dropdown-toggle dropdown-toggle-split" type="button" 
-        data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">+${
-          files.length - 1
-        }
-        <span class="visually-hidden">Toggle Dropdown</span>
-        </button>
-        <div class="dropdown-menu dropdown-menu-dark" aria-labelledby="dropdownMenuButton">`;
+    container.className = "btn-group dropup pointer";
+
+    const nameSpan = document.createElement("span");
+    nameSpan.className = `filename ${isSaved}`;
+    nameSpan.textContent = label;
+    nameSpan.setAttribute("title", titleText);
+    container.appendChild(nameSpan);
+
+    const countBtn = document.createElement("button");
+    countBtn.id = "filecount";
+    countBtn.className = "btn btn-dark dropdown-toggle dropdown-toggle-split";
+    countBtn.type = "button";
+    countBtn.setAttribute("data-bs-toggle", "dropdown");
+    countBtn.setAttribute("aria-haspopup", "true");
+    countBtn.setAttribute("aria-expanded", "false");
+    countBtn.innerHTML = `+${files.length - 1} <span class="visually-hidden">Toggle Dropdown</span>`;
+    container.appendChild(countBtn);
+
+    const menu = document.createElement("div");
+    menu.className = "dropdown-menu dropdown-menu-dark";
+    menu.setAttribute("aria-labelledby", "dropdownMenuButton");
+
     files.forEach((item) => {
       if (item !== openFile) {
-        const label = item.split(/[\\/]/).pop();
-        appendStr += `<a id="${item}" class="dropdown-item openFiles" href="#">
-                <span class="material-symbols-outlined align-bottom">audio_file</span>${label}</a>`;
+        const a = document.createElement("a");
+        a.setAttribute("id", item);
+        a.className = "dropdown-item openFiles";
+        a.href = "#";
+        const icon = document.createElement("span");
+        icon.className = "material-symbols-outlined align-bottom";
+        icon.textContent = "audio_file";
+        const itemLabel = document.createTextNode(item.split(/[\\/]/).pop());
+        a.appendChild(icon);
+        a.appendChild(itemLabel);
+        menu.appendChild(a);
       }
     });
-    appendStr += `</div></div>`;
+    container.appendChild(menu);
   } else {
-    appendStr = `<div id="fileContainer">
-        <button class="btn btn-dark" type="button" id="dropdownMenuButton">
-        <span ${title} class="filename ${isSaved}">${label}</span>
-        </button></div>`;
+    const button = document.createElement("button");
+    button.className = "btn btn-dark";
+    button.type = "button";
+    button.id = "dropdownMenuButton";
+
+    const nameSpan = document.createElement("span");
+    nameSpan.className = `filename ${isSaved}`;
+    nameSpan.textContent = label;
+    nameSpan.setAttribute("title", titleText);
+    button.appendChild(nameSpan);
+    container.appendChild(button);
   }
 
-  filenameElement.innerHTML = appendStr;
+  // Replace container contents safely
+  filenameElement.appendChild(container);
   // Adapt menu
   customiseAnalysisMenu(isSaved === "text-info");
 }

--- a/js/ui.js
+++ b/js/ui.js
@@ -836,7 +836,7 @@ function renderFilenamePanel() {
   const { parentFolder, fileName } = utils.extractFileNameAndFolder(openFile);
   const label = `${parentFolder}/${fileName}`;
   let appendStr;
-  const title = ` title="${i18.filename}" `;
+  const title = ` title="${openFile}\n---\n${i18.filename}" `;
   const isSaved = ["archive", "explore"].includes(STATE.mode)
     ? "text-info"
     : "text-warning";
@@ -8324,6 +8324,7 @@ function renderComparisons(lists, cname) {
 }
 import WaveSurfer from "../node_modules/wavesurfer.js/dist/wavesurfer.esm.js";
 import Spectrogram from "../node_modules/wavesurfer.js/dist/plugins/spectrogram.esm.js";
+import TimelinePlugin from "../node_modules/wavesurfer.js/dist/plugins/timeline.esm.js";
 
 let ws;
 
@@ -8393,6 +8394,21 @@ const createCompareWS = (mediaContainer) => {
       })
     );
   createCmpSpec();
+  const createTimeline = () =>
+    ws.registerPlugin(
+    TimelinePlugin.create({
+      timeInterval: 0.25,
+      primaryLabelInterval: 1,
+      secondaryLabelInterval: 0.25,
+      secondaryLabelOpacity: 0,
+      style: {
+        // boostrap light and dark
+        color: '#f8f9fa',
+        backgroundColor: '#212529'
+      },
+    })
+  );
+  createTimeline();
 };
 
 function showCompareSpec() {


### PR DESCRIPTION
Add a timeline to the reference call comparison

Add full file path to filename title on transport bar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File tooltips now display the full file path alongside the localized filename.
  * Comparison spectrograms now include a timeline with 0.25-second intervals.
  * Timeline styling adapts to light and dark display themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->